### PR TITLE
Edits Dalı Güncellendi

### DIFF
--- a/Eureka/main.py
+++ b/Eureka/main.py
@@ -8,10 +8,23 @@ from parser import *
 tokens=[]
 symbols = {}
 
-def run():
+def run_shell():
+    print("Eureka 2017 (C) MIT Licence \n \n")
+    while True:
+        data = input("<?>: ")
+        toks = lex(data)
+        parser(toks , symbols)
+        ###print(symbols)
+
+
+def run_file():
     data = open_file(argv[1])
     toks = lex(data)
     parser(toks , symbols)
     ###print(symbols)
 
-run()
+try:
+    test = argv[1]
+    run_file()
+except:
+    run_shell()

--- a/src/main.py
+++ b/src/main.py
@@ -8,10 +8,23 @@ from parser import *
 tokens=[]
 symbols = {}
 
-def run():
+def run_shell():
+    print("Eureka 2017 (C) MIT Licence \n \n")
+    while True:
+        data = input("<?>: ")
+        toks = lex(data)
+        parser(toks , symbols)
+        ###print(symbols)
+
+
+def run_file():
     data = open_file(argv[1])
     toks = lex(data)
     parser(toks , symbols)
     ###print(symbols)
 
-run()
+try:
+    test = argv[1]
+    run_file()
+except:
+    run_shell()


### PR DESCRIPTION
`argv[1]` ya da komut satırında `python main.py dosya_ismi` yerine dosya ismini boş bırakırsanız artık sizi bir hata mesajı yerine bir `Kabuk(shell)` karşılayacak